### PR TITLE
Admin side order

### DIFF
--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -1,2 +1,22 @@
 class Admin::OrderItemsController < ApplicationController
+  def update
+    order_item = OrderItem.find(params[:id])
+    order = Order.find(order_item.order_id)
+    if order_item.update(order_item_params) && params[:order_item][:making_status] == "制作中"
+    # ステータスのupdateが成功、なおかつそのステータスが"制作中"だった場合order.statusを"制作中"に変更
+      order.update(status: "制作中")
+    elsif order_item.update(order_item_params) && params[:order_item][:making_status] == "制作完了"
+      if order.order_items.count == order.order_items.where(making_status: "制作完了").count
+      # orderに紐付いたorder_itemのレコードの件数と、orderに紐付いたmaking_statusが"制作完了"のレコードの件数が同じだった場合、order.statusを"発送準備中"に変更
+        order.update(status: "発送準備中")
+      end
+    end
+    redirect_back fallback_location: root_path
+  end
+  
+  private
+  
+  def order_item_params
+    params.require(:order_item).permit(:making_status)
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,2 +1,26 @@
 class Admin::OrdersController < ApplicationController
+  
+  def index
+    @orders = Order.page(params[:page]).reverse_order
+  end
+  
+  def show
+    @order = Order.find(params[:id])
+    @customer = Customer.find(@order.customer_id)
+    @order_items = @order.order_items
+  end
+  
+  def update
+    order = Order.find(params[:id])
+    if order.update(order_params) && params[:order][:status] = "入金確認"
+      order.order_items.update_(making_status: "制作待ち")
+    end
+    redirect_back fallback_location: root_path
+  end
+  
+  private
+  
+  def order_params
+    params.require(:order).permit(:status)
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,7 +1,12 @@
 class Admin::OrdersController < ApplicationController
   
   def index
-    @orders = Order.page(params[:page]).reverse_order
+  # params[:customer_id]に値が入っていたら@ordersにその顧客の注文一覧を代入する
+    if params[:customer_id].present?
+      @orders = Customer.find(params[:customer_id]).orders.page(params[:page]).reverse_order
+    else
+      @orders = Order.page(params[:page]).reverse_order
+    end
   end
   
   def show
@@ -21,6 +26,6 @@ class Admin::OrdersController < ApplicationController
   private
   
   def order_params
-    params.require(:order).permit(:status)
+    params.require(:order).permit(:status, )
   end
 end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,9 +1,2 @@
 module Admin::OrdersHelper
-  def order_quantity(order)
-    array = []
-    order.order_items.each do |order_item|
-      array << order_item.amount
-    end
-    array.sum
-  end
 end

--- a/app/helpers/admin/orders_helper.rb
+++ b/app/helpers/admin/orders_helper.rb
@@ -1,2 +1,9 @@
 module Admin::OrdersHelper
+  def order_quantity(order)
+    array = []
+    order.order_items.each do |order_item|
+      array << order_item.amount
+    end
+    array.sum
+  end
 end

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -41,4 +41,5 @@
 </table>
 
 <%= link_to "編集する", edit_admin_customer_path(@customer.id), class: "btn btn-success" %>
-<%= link_to "注文履歴一覧をみる", admin_orders_path, class: "btn btn-primary" %>
+<!--注文一覧ページでこのページの顧客注文一覧のみを表示させる条件分岐のためパラメータにcustomer_idを付与-->
+<%= link_to "注文履歴一覧をみる", admin_orders_path(customer_id: @customer.id), class: "btn btn-primary" %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,27 @@
+<h4>注文履歴一覧</h4>
+
+<table class="table table-bordered">
+  <thead>
+    <tr class="table-active">
+      <th>購入日時</th></th>
+      <th>購入者</th>
+      <th>注文個数</th>
+      <th>注文ステータス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @orders.each do |order| %>
+      <tr>
+        <th>
+          <%= link_to admin_order_path(order.id) do %>
+            <%= order.created_at.strftime( '%Y/%m/%d %H:%M:%S' )%>
+          <% end %>
+        </th>
+        <th><%= Customer.find(order.customer_id).full_name %></th>
+        <th><%= order_quantity(order) %></th>
+        <th><%= order.status %></th>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @orders %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -18,7 +18,7 @@
           <% end %>
         </th>
         <th><%= Customer.find(order.customer_id).full_name %></th>
-        <th><%= order_quantity(order) %></th>
+        <th><%= order.order_items.sum(:amount) %></th>
         <th><%= order.status %></th>
       </tr>
     <% end %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,0 +1,88 @@
+<h4 class="mt-4">注文履歴詳細</h4>
+<div class="row">
+  <%= form_with model: [:admin, @order], local: true do |f| %>
+    <table>
+      <tbody>
+        <tr height="40">
+          <th>購入者</td>
+          <td><%= link_to @customer.full_name, admin_customer_path(@customer.id) %></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr height="40">
+          <th>注文日</td>
+          <td><%= @order.created_at.strftime( '%Y/%m/%d' )%></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr height="40">
+          <th>発送先</td>
+          <td colspan="3">
+            〒<%= @order.zipcode %> <%= @order.address %><br>
+            <%= @order.name %>
+          </td>
+        </tr>
+        <tr height="40">
+          <th>支払い方法</td>
+          <td><%= @order.payment_method %></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr height="40">
+          <th>注文ステータス　</td>
+              <!--f.selectでenumの項目を選択肢として表示、デフォルト値はorder_item.making_status-->
+              <!--OrderItem.makin_statusesでOrderモデルで規定したenum status: の値をハッシュで取得-->
+              <!--.keysメソッドでハッシュ内のkeyのみを配列化 >["入金待ち", "入金確認", "制作中", "発送準備中", "発送済み"]-->
+          <td><%= f.select :status, Order.statuses.keys, selected: @order.status %></td>
+          <td><%= f.submit "更新", class: "btn btn-success btn-sm" %></td>
+          <td></td>
+        </tr>    
+      </tbody>
+    </table>
+  <% end %>
+</div>
+
+<div class="row mt-5">
+  <div class="col-md-8 px-0">
+    <table class="table table-bordered mb-0">
+      <thead>
+        <tr class="table-active">
+          <th>商品名</th>
+          <th>単価(税込)</th>
+          <th>数量</th>
+          <th>小計</th>
+          <th>制作ステータス</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @order_items.each do |order_item| %>
+          <tr>
+            <td><%= order_item.product.name %></th>
+            <th><%= order_item.tax_in_price.to_s(:delimited) %></th>
+            <th><%= order_item.amount %></th>
+            <th><%= (order_item.tax_in_price * order_item.amount).to_s(:delimited) %></th>
+            <%= form_with model: order_item, url: admin_order_item_path(order_item.id), local: true do |f| %>
+              <th><%= f.select :making_status, OrderItem.making_statuses.keys, selected: order_item.making_status %></th>
+              <th><%= f.submit "更新", class: "btn btn-primary btn-sm" %></th>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <div class="col-md-3 mt-auto ml-auto">
+    <div class="row">
+      <div>
+        <p class="font-weight-bold">商品合計</p>
+        <p class="font-weight-bold">送料</p>
+        <p class="font-weight-bold mb-0">請求金額合計</p>
+      </div>
+      <div class="text-right ml-3">
+        <p><%= @order_items.sum(:tax_in_price).to_s(:delimited) %>円</p>
+        <p><%= @order.postage %>円</p>
+        <p class="font-weight-bold mb-0"><%= @order.total_price.to_s(:delimited) %>円</p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### 実施内容
admin側の注文一覧、注文詳細、注文ステータス、制作ステータス

### 注文ステータスのセレクトボックス（プルダウン）の実装方法
①`<%= f.select :status, Order.statuses.keys, selected: @order.status %>`
②`<%= f.select :status,  ["入金待ち", "入金確認", "制作中", "発送準備中", "発送済み"], selected: @order.status %>`
上の２つのコードの中身は同じです。selected: @order.status　で現在order.statusカラムに保存されているステータスをデフォルトの選択としています。
①のコードはOrderモデルで規定したenumの内容に対応しているので、ステータス名の変更や削除に自動的に対応してくれます。

`Order.statuses`　←これでOrderモデルで規定したenumの内容を持ってこれる
>{"入金待ち"=>0, "入金確認"=>1, "制作中"=>2, "発送準備中"=>3, "発送済み" =>4}
↑このままだとバリューの 0..4 がparamsのバリューとして送られるので、enumが受け入れてくれずエラーで弾かれます。

`Order.statuses.keys`
>["入金待ち", "入金確認", "制作中", "発送準備中", "発送済み"]
↑keysメソッドでハッシュ内のキーのみを配列化することで、enumが受入可能なバリューとなります。

参考サイト
https://railsdoc.com/page/select
https://qiita.com/HrsUed/items/56677d6c266d8a53ffa7
https://morizyun.github.io/ruby/rails-function-enum-select-tag.html

### 顧客詳細ページのリンクから注文一覧に遷移した場合、その顧客の注文一覧を表示する。
参考ページ
https://qiita.com/qz7_start/items/cbae7741a7dde5248ec6

今回はパラメータとしてcustomer_id が必要だったため、link_toにパラメータを付与する方法を使っています。